### PR TITLE
Add Dune: Awakening to 'Games we play' section (fixes #3)

### DIFF
--- a/src/home.html
+++ b/src/home.html
@@ -291,6 +291,31 @@
                         </div>
 
                         <div class="artists-thumb">
+                            <div class="artists-image-wrap">
+                                <img src="uploads/dune-awakening-placeholder.jpg" class="artists-image img-fluid" alt="Dune: Awakening">
+                            </div>
+
+                            <div class="artists-hover">
+                                <p>
+                                    <strong>Name:</strong>
+                                    Dune: Awakening
+                                </p>
+
+                                <p>
+                                    <strong>Ops Night:</strong>
+                                    Coming soon
+                                </p>
+
+                                <hr>
+
+                                <p class="mb-0">
+                                    <strong>More info:</strong>
+                                    <a href="#"><b>Coming soon</b></a>
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="artists-thumb">
                             <img src="uploads/MixCollage-15-Nov-2024-09-52-PM-2760.jpg" class="artists-image img-fluid">
 
                             <div class="artists-hover">


### PR DESCRIPTION
This PR adds Dune: Awakening to the 'Games we play' section on the homepage, including a placeholder image and details. Closes #3.